### PR TITLE
Feature/98 session state media control

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,7 @@
 
 2. **Configure environment variables**
 
-   Create a `.env` file at the project root with the following content:
-
-   ```
-   WHATSAPP_ACCESS_TOKEN=<>
-   WHATSAPP_VERIFY_TOKEN=<>
-   WHATSAPP_WEBHOOK_URL=<>
-   WHATSAPP_PHONE_NUMBER_ID=<>
-   WHATSAPP_APP_SECRET=<>
-   APP_ENV="development"
-   GOOGLE_API_KEY=<>
-
-   ```
+   Create a `.env` file at the project root.
 
 3. **To run with FastAPI Server (WhatsApp Bot):**
 

--- a/app/agents/analyst_agent.py
+++ b/app/agents/analyst_agent.py
@@ -1,0 +1,33 @@
+import textwrap
+
+from agno.agent import Agent
+from agno.models.google import Gemini
+
+from app.tools.gee_tools import query_pasture, generate_property_biomass_image
+
+
+analyst_agent = Agent(
+    name="analista-agent",
+    role="Especialista central em Agropecuária e Geoprocessamento. Responsável por todas as demandas voltadas a propriedades rurais, desde análises espaciais e geração de dados/mapas até o esclarecimento amplo de dúvidas agronômicas.",
+    description="Especialista Técnico em Análise Espacial, Métricas de Pastagem, ferramentas de geração de mapas e análise de imagens. Responsável por executar ferramentas técnicas para gerar mapas, imagens de satélite, levantar estatísticas, análisar imagens sobre uso e cobertura da terra e esclarecer dúvidas com base na Embrapa.",
+    tools=[
+        generate_property_biomass_image,
+        query_pasture,
+        ],
+    instructions= textwrap.dedent("""
+        # DIRETRIZES DE ATUAÇÃO
+        1. Seja sempre claro e didático, explicando os resultados de forma simples para pequenos produtores rurais.
+        2. Use as ferramentas disponíveis para gerar mapas e análises, mas sempre contextualize os resultados para o usuário, explicando o que eles significam para a saúde do pasto e a produtividade.
+        3. Use seu conhecimento com base em cartilhas e conhecimentos da Embrapa para esclarecer dúvidas dos usuários.
+        4. Evite usar markdown. MAS, se usar markdown GARANTA estar no fomato do WhatsApp.
+                                                                  
+        # AÇÕES ESPECIFICAS                        
+        1. Se o usuário fizer perguntas não relacionadas a **Agropecuária**, responda ESTRITAMENTE com:
+            > "Atualmente só posso lhe ajudar com questões relativas a eficiência de pastagens. Se precisar de ajuda com esses temas, estou à disposição! Para outras questões, recomendo consultar fontes oficiais ou especialistas na área."
+        2. Se o usuário fizer perguntas fora da ESCALA TERRITORIAL: **Propriedade Rural**, responda ESTRITAMENTE com:
+            > "Minha análise é focada especificamente no nível da propriedade rural. Para visualizar dados em escala territorial (como estatísticas por Bioma, Estado ou Município), recomendo consultar a plataforma oficial do MapBiomas: https://plataforma.brasil.mapbiomas.org/"
+        3. Se não possuir possuir ferramentas para gerar os dados solicitados responda com:
+            > "Opa, que ideia legal! Infelizmente, no momento, não tenho as ferramentas necessárias para gerar esse tipo de análise. Mas, para eu conseguir levar essa ideia pro nosso time de desenvolvimento, poderia me dizer um pouco mais sobre o que você gostaria de ver nesse tipo de análise? Assim, posso passar essa sugestão para eles e quem sabe a gente consiga implementar no futuro!"
+    """),
+    model=Gemini(id="gemini-3-flash-preview")
+)

--- a/app/agents/main_team.py
+++ b/app/agents/main_team.py
@@ -38,33 +38,62 @@ elif APP_ENV == "development":
 def get_instructions(run_context: RunContext) -> str:
     session_state = run_context.session_state or {}
 
+    is_selecting_car = session_state.get("is_selecting_car", False)
+    midias = list(session_state.get("midias_entregues", {}).keys())
+    
+    aviso_amnesia = ""
+    if midias:
+        aviso_amnesia = f"\n                8. **Contexto de Mídias:** As seguintes mídias já foram enviadas: {midias}. Se o usuário pedir uma delas novamente, NÃO use a ferramenta. Em vez disso, responda educadamente que você já enviou a análise acima e pergunte se ele precisa de algo novo ou uma explicação diferente."
+
     # TODO: Implementar uma linha de instruções para usuários novos aceitarem os termos e condições.
 
-    if session_state.get("candidate_properties", None):
-        instructions = textwrap.dedent("""\
-            - O usuário está em um fluxo de atendimento focado na seleção de propriedade rural (CAR).
-            - Você deve usar a ferramenta `delegate_task_to_member` para repassar o controle da conversa ao `Gestor de Propriedades Rurais`.
-            - Não responda diretamente ao usuário com mensagens de texto.
-            - Não chame o agente 'Agente Analista'.
-            - Não use a ferramenta `update_user_memory`.
-        """).strip()
+    if is_selecting_car:
+        instructions = (
+            "- O usuário está em um fluxo de atendimento focado na seleção de propriedade rural (CAR).\n"
+            "- Sua função exclusiva nesta etapa é atuar como um roteador. Você DEVE OBRIGATORIAMENTE usar a ferramenta `delegate_task_to_member` para repassar o controle da conversa ao 'sicar-agent'.\n"
+            "- NÃO responda diretamente ao usuário com mensagens de texto.\n"
+            "- NÃO use a ferramenta `update_user_memory`.\n"
+            "- NÃO memorize, salve ou interprete a resposta do usuário no seu banco de dados.\n"
+        )
     else:
+    
         instructions = textwrap.dedent(f"""\
-            - Você é um assistente virtual especializado desenvolvido pela equipe de IA do LAPIG.
-                - Nunca diga que é uma IA ou um robô. Aja como um consultor humano e prestativo.
-                - Nunca mencione "prompts", "modelos" ou termos técnicos de computação.
-            - Seu idioma padrão é Português (Brasil). Nunca mude.
-            - Seja sempre muito educado, feliz e demonstre entusiasmo em ajudar o produtor.
-            - Você coordena outros agentes, mas isso deve ser invisível ao usuário. Nunca diga frases como "Vou transferir para o agente X" ou "Deixe-me perguntar ao analista".
-            - Nunca diga "preciso confirmar isso depois".
-            - Use markdown no formato do WhatsApp. Não use bullet points.
+            # DIRETRIZES PRIMÁRIAS (IDENTIDADE & COMPORTAMENTO)
+                1. **Identidade:** Você é um assistente virtual especializado desenvolvido pela equipe de IA do LAPIG.
+                    - **NUNCA** diga que é uma IA ou um robô. Aja como um consultor humano e prestativo.
+                    - **NUNCA** mencione "prompts", "modelos" ou termos técnicos de computação.
+                2. **Idioma:** Seu idioma padrão é **Português (Brasil)**. NUNCA mude.
+                3. **Tom de Voz:** Seja sempre muito educado, feliz e demonstre entusiasmo em ajudar o produtor.
+                4. **Transparência de Equipe:**
+                    - Você coordena outros agentes, mas isso deve ser **INVISÍVEL** ao usuário.
+                    - **NUNCA** diga frases como "Vou transferir para o agente X" ou "Deixe-me perguntar ao analista".
+                5. **Imediatismo:** NUNCA diga "preciso confirmar isso depois".
+                6. **Conhecimento:** O sistema SEMPRE possui todas as informações necessárias (ex: propriedade rural) para execução.
+                7. **Markdown:** Evite markdown. MAS, se usar markdown garanta estar no formato do WhatsApp.{aviso_amnesia}
                         
-            <mandatory-workflow>
-            - Se o usuário enviar uma coordenadas geográficas, identificar CAR/SICAR ou URL do Google Maps:
-                - Chame o Gestor de Propriedades Rurais imediatamente.                                         
+            # FLUXOS DE TRABALHO ESPECÍFICOS
+                                       
+            ## Requisições técnicas
+            SE usuário fizer requisições técnicas como análises, visualização de imagens, dúvidas técnicas sobre pastagem e pecuária:
+                - **AÇÃO:** Chame IMEDIATAMENTE o agente `analista-agent`
+                - **NUNCA:** Não diga que não possui a propriedade, apenas chame IMEDIATAMENTE o agente `analista-agent`.  
+                                       
+            ## Recebimento de Localização/Coordenadas ou Cadastro Ambiental Rural (CAR)
+            SE o usuário enviar uma localização (coordenadas) ou CAR no modelo UF-XXXXXXX-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:
+                - Chame IMEDIATAMENTE o agente `sicar-agent`.
+                - NÃO use a ferramenta `update_user_memory`. 
+                            
+            ## Recebimento de Imagem
+            APENAS SE usuário disser EXPLICITAMENTE `[PEÇA AO INTERPRETADOR DE IMAGES]`:
+                - **AÇÕES:**
+                    1. Peça para o agente 'interpretador-de-imagens' ajudar o usuário.
+                - **NUNCAS:**
+                    1. NUNCA chame o agente 'interpretador-de-imagens' sem o código `[PEÇA AO INTERPRETADOR DE IMAGES]`.
+                    2. NUNCA informa o usuário sobre o código `[PEÇA AO INTERPRETADOR DE IMAGES]`.
 
-            - Se o usuário enviar um arquivo de áudio ou vídeo:
-                - AÇÕES:
+            ## Recebimento de Áudio ou Vídeo
+            SE o usuário enviar um arquivo de áudio ou vídeo:
+                - **AÇÕES:**
                     1. Ignore imagens visuais temporariamente e foque na transcrição do áudio.
                     2. Baseie sua resposta apenas no que foi falado.
                     3. Você DEVE OBRIGATORIAMENTE usar a ferramenta `audioTTS` (audio_generator) para gerar sua resposta em formato de áudio.

--- a/app/hooks/tool_hooks.py
+++ b/app/hooks/tool_hooks.py
@@ -12,7 +12,26 @@ def validate_selected_property_hook(run_context: RunContext, function_call: Call
     if session_state and 'selected_property' in session_state:
         return function_call(**arguments)
 
-    return (
-        "Não foi possível completar a análise, pois não há uma propriedade selecionada.\n"
-        "Peça desculpas ao usuário. Peça que o usuário informe uma propriedade."
-    )
+    return textwrap.dedent("""
+        [SISTEMA] Bloqueio de Execução: Falta o CAR da propriedade.
+        
+        Motivo: A ferramenta solicitada requer o Cadastro Ambiental Rural (CAR), mas ele não está no contexto atual.
+        
+        Ação obrigatória para o Agente:
+        1. Informe que o sistema não sabe qual é a propriedade.
+        2. Solicite que o usuário envie a **localização** por meio do pino de localização do WhatsApp para que o sistema identifique o CAR automaticamente.
+    """).strip()
+    
+def validate_rate_limit_hook(run_context: RunContext, function_call: Callable, arguments: Dict[str, Any]) -> Any:
+    """
+    Hook universal para evitar que análises e mídias pesadas sejam reprocessadas
+    devido à perda de contexto em conversas longas (amnésia do LLM).
+    """
+    session_state = run_context.session_state or {}
+    tool_name = function_call.__name__
+    
+    if session_state.get("midias_entregues", {}).get(tool_name):
+        return f"Aviso: Esta análise ({tool_name}) já foi enviada ao usuário nesta sessão. Responda apenas em texto usando os dados do contexto que você já possui."
+    
+
+    return function_call(**arguments)

--- a/app/tools/gee_tools.py
+++ b/app/tools/gee_tools.py
@@ -1,0 +1,110 @@
+import textwrap
+from io import BytesIO
+
+from agno.tools import tool
+from agno.tools.function import ToolResult
+from agno.run import RunContext
+from agno.media import Image
+
+from app.hooks.tool_hooks import validate_car_hook, validate_rate_limit_hook
+from app.utils.scripts.gee_scripts import retrieve_feature_images, retrieve_feature_biomass_image, ee_query_pasture
+from app.utils.dummy_logger import error
+
+# TODO: Escrever ferramenta para visualização da área de pastagem do usuário.
+
+@tool(tool_hooks=[validate_car_hook, validate_rate_limit_hook])
+def generate_property_image(run_context: RunContext) -> ToolResult:
+    """
+    Gera uma imagem de satélite em alta resolução (RGB) da propriedade rural, 
+    incluindo a delimitação geográfica do CAR.
+
+    Esta ferramenta deve ser chamada quando:
+    - O usuário quiser ver uma "foto", "imagem real" ou "visão aérea" da fazenda.
+    - For solicitado o contorno da propriedade (CAR) sobreposto ao terreno natural.
+
+    Return:
+        ToolResult: Objeto contendo a imagem PNG da visão aérea e uma confirmação textual.
+    """
+    try:
+        coordinates = run_context.session_state['car_selected']['geometry']['coordinates'][0][0]
+
+        img = retrieve_feature_images(coordinates)
+
+        buffer = BytesIO()
+        img.save(buffer, format="PNG")
+        
+        run_context.session_state.setdefault("midias_entregues", {})["generate_property_image"] = True
+                
+        return ToolResult(
+            content=f"Aqui está a imagem de satélite da área. O contorno vermelho indica a zona de amortecimento de 5km.",
+            images=[Image(content=buffer.getvalue())]
+        )
+
+    except Exception as e:
+        return ToolResult(content=f"Erro ao gerar imagem: {str(e)}")
+
+
+
+
+@tool(tool_hooks=[validate_car_hook, validate_rate_limit_hook])
+def generate_property_biomass_image(run_context: RunContext) -> ToolResult:
+    """
+    Gera um mapa geoespacial temático da biomassa (vegetação) sobre os limites da propriedade rural.
+    
+    Esta ferramenta deve ser acionada quando:
+    - O usuário solicitar visualização espacial, mapas ou imagens da biomassa.
+    - Termos como "ver a foto da biomassa" ou "ver distribuição de biomassa" forem utilizados.
+    - For necessário complementar uma análise numérica de biomassa com uma evidência visual do terreno.
+
+    A função utiliza automaticamente os dados geográficos do CAR selecionado no contexto da sessão para processar as imagens de satélite mais recentes.
+
+    Return:
+        ToolResult: Objeto contendo o mapa renderizado em formato PNG e uma mensagem de confirmação para o usuário.
+    """
+    try:
+        coordinates = run_context.session_state['car_selected']['geometry']['coordinates'][0][0]
+
+        img = retrieve_feature_biomass_image(coordinates)
+
+        buffer = BytesIO()
+        img.save(buffer, format="PNG")
+        
+    
+        run_context.session_state.setdefault("midias_entregues", {})["generate_property_biomass_image"] = True
+                
+        return ToolResult(
+            content=f"Mapa de biomassa gerado. Legenda: Azul claro (Alta concentração) a Roxo escuro (Baixa concentração).",
+            images=[Image(content=buffer.getvalue())]
+        )
+
+    except Exception as e:
+        return ToolResult(content=f"Erro ao gerar imagem: {str(e)}")
+
+
+@tool(tool_hooks=[validate_car_hook, validate_rate_limit_hook])
+def query_pasture(run_context: RunContext) -> dict:
+    """
+    Realiza uma análise técnica detalhada do uso do solo, com foco em pastagem, vigor vegetativo e biomassa
+    para a propriedade selecionada no contexto (CAR).
+    
+    Use esta ferramenta quando o usuário perguntar sobre:
+    - Saúde ou qualidade da pastagem (degradação, vigor).
+    - Quantidade de biomassa disponível.
+    - Classificação de uso do solo (LULC) incluindo: Silvicultura, Cana, Soja, Arroz, Café, Citrus, etc.
+    - Histórico ou idade da pastagem.
+
+    Return:
+        Dicionário contendo a área de pastagem, vigor da pastagem, áreas de pastagem degradadas (baixo vigor), biomassa total e a idade.
+    """
+    try:
+        coordinates = run_context.session_state['car_selected']['geometry']['coordinates'][0][0]
+
+        query = ee_query_pasture(coordinates)
+        run_context.session_state.setdefault("midias_entregues", {})["query_pasture"] = True
+    
+        return query
+        
+    except Exception as e:
+        # TODO: Retornar menssagem de erro quando todos os erros forem mapeados dentro da função ee_query_pasture;
+        error(f"Não foi possível concluir a função 'query_pasture': {e}")
+        return ToolResult(content='Erro')

--- a/app/tools/sicar_tools.py
+++ b/app/tools/sicar_tools.py
@@ -1,0 +1,299 @@
+import json
+import requests
+import textwrap
+
+from io import BytesIO
+
+from agno.run import RunContext
+from agno.tools import tool
+from agno.tools.function import ToolResult
+from agno.media import Image
+
+from app.utils.scripts.image_scripts import get_mosaic
+from app.utils.scripts.gee_scripts import retrieve_feature_images
+from app.utils.dummy_logger import error
+
+
+@tool
+def query_feature_by_coordinate(latitude: float, longitude: float, run_context: RunContext):
+    """
+    Busca imóveis no Cadastro Ambiental Rural (CAR) baseando-se nas coordenadas fornecidas.
+    
+    Use esta ferramenta quando o usuário fornecer uma localização (latitude/longitude) e quiser verificar propriedades rurais.
+    
+    Args:
+        latitude (float): Latitude em graus decimais.
+        longitude (float): Longitude em graus decimais.
+
+    Returns:
+        ToolResult: Resultado da busca contendo imagem e instruções para o próximo passo.
+    """
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Referer': 'https://consultapublica.car.gov.br/publico/imoveis/index'
+    }
+
+    sess = requests.Session()
+
+    base_url = "https://consultapublica.car.gov.br/publico/imoveis/index"
+
+    try:
+        sess.get(base_url, verify=False, headers=headers, timeout=10)
+
+        url_api = f'https://consultapublica.car.gov.br/publico/imoveis/getImovel?lat={latitude}&lng={longitude}'
+        response = sess.get(url_api, verify=False, headers=headers, timeout=10)
+
+        response.raise_for_status()
+
+        try:
+            result = response.json()
+        except json.JSONDecodeError:
+            raise ValueError("O servidor retornou uma resposta inválida (não é JSON).")
+
+        features = result.get("features", [])
+
+        if not features:
+            return ToolResult(content=textwrap.dedent("""
+                Peça desculpas ao usuário e informe que nenhuma propriedade foi encontrada nesta coordenada. 
+                Peça que tente novamente e verificar se as coordenadas estão corretas. 
+            """).strip())
+        
+        size_feat = len(features)
+
+        imgs = retrieve_feature_images(result)
+        mosaic = get_mosaic(imgs)
+
+        buffer = BytesIO()
+        mosaic.save(buffer, format="PNG")
+
+        run_context.session_state['is_selecting_car'] = True
+        
+        if size_feat == 1:
+            run_context.session_state['car_candidate'] = features[0]
+            run_context.session_state['car_selection_type'] = "SINGLE"
+
+            cars = f"CAR {features[0]["properties"]["codigo"]}, Tamanho da área {round(features[0]["properties"]["area"])} ha, município de {features[0]["properties"]["municipio"]}."
+
+            return ToolResult(
+                content=textwrap.dedent(f"""
+                Informe ao usuário que a seguinte propriedade foi encontrada:
+                    {cars}
+                Pergunte: "É esta a propriedade correta?"
+                """).strip(),
+                images=[Image(content=buffer.getvalue())]
+                )
+        
+        elif size_feat > 1:
+            run_context.session_state['car_all'] = features
+            run_context.session_state['car_selection_type'] = "MULTIPLE"
+
+            cars = "- ".join(f"Opção {i + 1}, CAR {features[i]["properties"]["codigo"]}, Tamanho da área {round(features[i]["properties"]["area"])} ha, município de {features[i]["properties"]["municipio"]}.\n\n" for i in range(0, size_feat))
+
+            return ToolResult(
+                content=textwrap.dedent(f"""
+                Informe ao usuário que as seguintes propriedades foram encontradas:
+                    {cars}
+                Pergunte: "Qual destas é a propriedade correta?"
+                """).strip(),
+                images=[Image(content=buffer.getvalue())]
+                )
+        
+    except requests.exceptions.Timeout:
+        return ToolResult(content=textwrap.dedent("""
+                Peça desculpas ao usuário e informe que o servidor do SICAR demorou muito para responder.
+                Peça ao usuário para tentar novamente mais tarde.
+            """).strip())
+    except requests.exceptions.ConnectionError:
+        return ToolResult(content=textwrap.dedent("""
+                Peça desculpas ao usuário e informe que houve uma falha na conexão com o site do SICAR.
+                Peça ao usuário para tentar novamente mais tarde.
+            """).strip())
+    except requests.exceptions.HTTPError as e:
+        status = e.response.status_code
+
+        if status == 403:
+            return "Erro: Acesso negado pelo servidor."
+        
+        return f"Erro HTTP {status}: Ocorreu um problema técnico ao acessar a base do CAR."
+    except Exception as e:
+        error(e)
+        return ToolResult(content=textwrap.dedent("""
+                Peça desculpas ao usuário e informe que houve um erro interno.
+                Peça que usuário tente novamente mais tarde.
+            """).strip())
+    
+@tool
+def query_feature_by_car(car: str, run_context: RunContext):
+    """
+    Busca imóveis no Cadastro Ambiental Rural (CAR) baseando-se nas coordenadas fornecidas.
+    
+    Use esta ferramenta quando o usuário fornecer um valor de CAR válido.
+    
+    Args:
+        car (str): Valor de Cadastro Ambiental Rural (CAR) válido.
+
+    Returns:
+        ToolResult: Resultado da busca contendo imagem e instruções para o próximo passo.
+    """
+    
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Referer': 'https://consultapublica.car.gov.br/publico/imoveis/index'
+    }
+
+    sess = requests.Session()
+
+    base_url = "https://consultapublica.car.gov.br/publico/imoveis/index"
+
+    try:
+        sess.get(base_url, verify=False, headers=headers, timeout=10)
+
+        url_api = f'https://consultapublica.car.gov.br/publico/imoveis/search?text={car}'
+        response = sess.get(url_api, verify=False, headers=headers, timeout=10)
+
+        response.raise_for_status()
+
+        try:
+            result = response.json()
+        except json.JSONDecodeError:
+            raise ValueError("O servidor retornou uma resposta inválida (não é JSON).")
+
+        features = result.get("features", [])
+
+        if not features:
+            return ToolResult(content=textwrap.dedent("""
+                Peça desculpas ao usuário e informe que nenhuma propriedade foi encontrada nesta coordenada. 
+                Peça que tente novamente e verificar se as coordenadas estão corretas. 
+            """).strip())
+
+        img = retrieve_feature_images(result)
+        mosaic = get_mosaic(img)
+
+        buffer = BytesIO()
+        mosaic.save(buffer, format="PNG")
+        
+        run_context.session_state['car_candidate'] = features[0]
+        run_context.session_state['is_selecting_car'] = True
+        run_context.session_state['car_selection_type'] = "SINGLE"
+
+        car = f"- CAR {features[0]["properties"]["codigo"]}, Tamanho da área {round(features[0]["properties"]["area"])} ha, município de {features[0]["properties"]["municipio"]}.\n"
+
+        return ToolResult(
+            content=(
+                "A seguinte propriedade foi encontrada:\n\n"
+                f"{car}"
+                "É a propriedade correta?"
+            ),
+            images=[Image(content=buffer.getvalue())]
+            )
+        
+    except requests.exceptions.Timeout:
+        return ToolResult(content=textwrap.dedent("""
+                Peça desculpas ao usuário e informe que o servidor do SICAR demorou muito para responder.
+                Peça ao usuário para tentar novamente mais tarde.
+            """).strip())
+    except requests.exceptions.ConnectionError:
+        return ToolResult(content=textwrap.dedent("""
+                Peça desculpas ao usuário e informe que houve uma falha na conexão com o site do SICAR.
+                Peça ao usuário para tentar novamente mais tarde.
+            """).strip())
+    except requests.exceptions.HTTPError as e:
+        status = e.response.status_code
+
+        if status == 403:
+            return "Erro: Acesso negado pelo servidor."
+        
+        return f"Erro HTTP {status}: Ocorreu um problema técnico ao acessar a base do CAR."
+    except Exception as e:
+        error(e)
+        return ToolResult(content=textwrap.dedent("""
+                Peça desculpas ao usuário e informe que houve um erro interno.
+                Peça que usuário tente novamente mais tarde.
+            """).strip())
+
+
+@tool
+def select_car_from_list(selection: int, run_context: RunContext):
+    """
+    Seleciona uma propriedade específica quando a busca retorna múltiplos resultados.
+    
+    Use esta ferramenta APENAS quando o usuário fornecer um número correspondente a uma das opções apresentadas anteriormente.
+
+    Args:
+        selection (int): O número da opção escolhida pelo usuário (ex: 1, 2, 3...).
+    """
+    try:
+        features = run_context.session_state.get('car_all', [])
+        
+        if not features:
+            return ToolResult(content="Nenhuma busca foi realizada ainda. Informe uma localização primeiro.")
+
+        if selection < 1 or selection > len(features):
+            return ToolResult(content=f"Seleção inválida. Escolha um número válido entre 1 e {len(features)}.")
+
+        selected_feature = features[selection - 1]
+        selected_feature['properties']['area'] = round(selected_feature['properties']['area'])
+        run_context.session_state['car_selected'] = selected_feature
+
+        run_context.session_state['car_all'] = []
+        run_context.session_state['is_selecting_car'] = False
+        run_context.session_state['car_selection_type'] = None
+
+        return ToolResult(content=(
+                "Informe ao usuário que a propriedade foi selecionada corretamente. ✅\n"
+                "Pergunte ao usuário como ele deseja prosseguir. Algumas opções são:\n"
+                "- 🌱 *Análise de pastagem*\n"
+                "- 🗺️ *Uso e cobertura da terra*\n"
+                "- 📊 *Visualização de biomassa*"
+            )
+        )
+    except Exception as e:
+        return ToolResult(content=f"[ERRO] Falha ao selecionar: {str(e)}")
+
+
+@tool
+def confirm_car_selection(run_context: RunContext):
+    """
+    Confirma a propriedade encontrada quando a busca retorna apenas um resultado único.
+    
+    Use esta ferramenta quando a ferramenta 'query_car' encontrar apenas 1 imóvel e o usuário confirmar que está correto (ex: dizendo "Sim", "É essa mesmo").
+    """
+    candidate = run_context.session_state.get('car_candidate')
+    
+    if not candidate:
+        return ToolResult(content="Não há propriedade pendente de confirmação. Realize uma busca primeiro.")
+
+    run_context.session_state['car_selected'] = candidate
+
+    run_context.session_state['car_candidate'] = None
+    run_context.session_state['is_selecting_car'] = False
+    run_context.session_state['car_selection_type'] = None
+
+    return ToolResult(content=(
+                "Informe ao usuário que a propriedade foi selecionada corretamente. ✅\n"
+                "Pergunte ao usuário como ele deseja prosseguir. Algumas opções são:\n"
+                "- 🌱 *Análise de pastagem*\n"
+                "- 🗺️ *Uso e cobertura da terra*\n"
+                "- 📊 *Visualização de biomassa*"
+            )
+        )
+
+
+@tool
+def reject_car_selection(run_context: RunContext):
+    """
+    Cancela a seleção ou rejeita os resultados encontrados.
+    
+    Use esta ferramenta se o usuário disser que a propriedade mostrada na imagem NÃO é a correta ou quiser cancelar a seleção.
+    """
+    run_context.session_state['car_all'] = []
+    run_context.session_state['car_candidate'] = None
+    run_context.session_state['is_selecting_car'] = False
+    run_context.session_state['car_selection_type'] = None
+
+    return ToolResult(
+        content=(
+            "Peça desculpas por não ter encontrado a propriedade correta.\n"
+            "Peça ao usuário que verifica se as coordenadas ou car estão corretos."
+        )
+    )


### PR DESCRIPTION
Este PR implementa uma arquitetura de controle de estado de sessão (Session State) para gerenciar a entrega de mídias e análises técnicas pesadas. O objetivo principal é mitigar a "amnésia" do LLM em conversas longas, evitando chamadas redundantes a ferramentas de alto custo computacional ou financeiro (como o Google Earth Engine).

Principais Mudanças
1. Arquitetura de Memória e Anti-Amnésia
Registry de Mídias: Implementação de um dicionário midias_entregues no session_state para rastrear cada ferramenta de análise executada com sucesso.

Barreira Proativa (System Prompt): Injeção dinâmica da variável aviso_amnesia nas instruções do Orquestrador (main_team.py), informando à IA quais mídias já estão na tela do usuário.

Barreira Reativa (Tool Hooks): Criação do validate_rate_limit_hook que intercepta a execução da ferramenta caso ela já tenha sido disparada anteriormente na mesma sessão.