### PR TITLE
Refatoração: Hooks como Interceptores de Execução nas Tools de Mídia

### DIFF
--- a/app/agents/main_team.py
+++ b/app/agents/main_team.py
@@ -66,11 +66,15 @@ def get_instructions(run_context: RunContext) -> str:
         else:
             
             persona_instructions = '- DESCOBERTA DE PERSONA: Nos primeiros contatos, descubra de forma muito sutil se o usuário atua como "produtor gerindo sua área" ou "técnico prestando consultoria", para adaptar seu atendimento.\n- Assim que você descobrir o nome, a cidade e a profissão do usuário, você é OBRIGADO a chamar a ferramenta set_user_persona.'
+        delivered_media = session_state.get("delivered_media", {})
+        media_instructions = ""
+        if delivered_media:
+            media_instructions = "- AVISO DE CONTEXTO (ANTI-AMNÉSIA): Você já entregou mídias/mapas nesta sessão. NÃO acione especialistas para gerar mapas ou imagens novamente, a menos que o usuário exija explicitamente um reenvio ou atualização."
 
         instructions = textwrap.dedent(f"""\
             <registrations>
             {registrations_text}
-            <registrations>  
+            </registrations>  
 
             <instructions>
             - Você é um assistente virtual especializado desenvolvido pela equipe de IA do LAPIG.
@@ -79,6 +83,7 @@ def get_instructions(run_context: RunContext) -> str:
             - Seu idioma padrão é Português (Brasil). Nunca mude.
             - Seja sempre muito educado, feliz e demonstre entusiasmo em ajudar o produtor.
             {persona_instructions}
+            {media_instructions}
             - Você coordena outros agentes, mas isso deve ser invisível ao usuário. Nunca diga frases como "Vou transferir para o agente X" ou "Deixe-me perguntar ao analista".
             - Nunca diga "preciso confirmar isso depois".
             - Se a resposta do membro da equipe for para o usuário, entregue-a integralmente, sem alterações ou comentários adicionais.

--- a/app/hooks/tool_hooks.py
+++ b/app/hooks/tool_hooks.py
@@ -1,10 +1,6 @@
 import json
-
-from datetime import datetime
 from typing import Callable, Dict, Any
-
 from agno.run import RunContext
-
 
 def validate_selected_property_hook(run_context: RunContext, function_call: Callable, arguments: Dict[str, Any]) -> Any:
     """
@@ -20,56 +16,45 @@ def validate_selected_property_hook(run_context: RunContext, function_call: Call
         "Peça desculpas ao usuário. Peça que o usuário informe uma propriedade."
     )
 
-
-def validate_rate_limit_hook(run_context: Any, function_call: Callable, arguments: Dict[str, Any]) -> Any:
+def validate_rate_limit_hook(run_context: RunContext, function_call: Callable, arguments: Dict[str, Any]) -> Any:
     """
-    Hook universal para evitar que análises e mídias pesadas sejam reprocessadas
-    devido à perda de contexto em conversas longas (amnésia do LLM).
+    Hook Interceptor: Gerencia o cache e a execução das ferramentas de mídia.
+    Evita reprocessamento desnecessário, economiza requisições e filtra falsos positivos.
     """
-    session_state = run_context.session_state or {}
-    
-    delivered_media: Dict[str, Dict[str, Any]] = session_state.get("delivered_media", {})
 
-    clean_args = {k: v for k, v in arguments.items() if k not in ['run_context', 'session', 'session_state']}
-
-    today = datetime.now().date()
-
-    key_data = {
-        "function_name": function_call.__name__,
-        "arguments": clean_args,
-        "date": today.isoformat()
-    }
-    search_key = json.dumps(key_data, sort_keys=True)
-
-    delete_list = []
-    for key, value_data in delivered_media.items():
-        entry_date_str = value_data.get("timestamp")
-        
-        if entry_date_str:
-            entry_date = datetime.fromisoformat(entry_date_str).date()
-            dias_passados = (today - entry_date).days
-            
-            if dias_passados > 6:
-                delete_list.append(key)
-
-    for key in delete_list:
-        del delivered_media[key]
-
-    if search_key in delivered_media and delivered_media[search_key].get("delivered") is True:
-        tool_name = function_call.__name__
-        return (
-            f"Aviso: Esta análise ({tool_name}) já foi enviada ao usuário nesta sessão. "
-            f"Responda apenas em texto usando os dados do contexto que você já possui."
-        )
-
-    delivered_media[search_key] = {
-        "delivered": True,
-        "timestamp": today.isoformat()
-    }
-    
     if run_context.session_state is None:
         run_context.session_state = {}
-        
-    run_context.session_state["delivered_media"] = delivered_media
+    
+    midias_entregues = run_context.session_state.get("midias_entregues", {})
 
-    return function_call(**arguments)
+    clean_args = {k: v for k, v in arguments.items() if k not in ['run_context', 'session', 'session_state']}
+    key_data = {
+        "function_name": function_call.__name__,
+        "arguments": clean_args
+    }
+
+    search_key = json.dumps(key_data, sort_keys=True)
+
+    if search_key in midias_entregues:
+        tool_name = function_call.__name__
+        return (
+            f"Aviso: A mídia solicitada ({tool_name}) já foi gerada com esses exatos parâmetros e entregue nesta sessão. "
+            f"Avise ao usuário que a imagem já está no histórico da conversa."
+        )
+
+
+    try:
+        result = function_call(**arguments)        
+        if hasattr(result, 'content') and "Erro" in str(result.content):
+            return result
+        
+        if not hasattr(result, 'images') or not result.images:
+             return "Erro: A integração com o satélite retornou uma mídia vazia. Tente novamente."
+
+        midias_entregues[search_key] = True
+        run_context.session_state["midias_entregues"] = midias_entregues
+
+        return result
+
+    except Exception as e:
+        return f"Erro na integração externa: Falha ao executar {function_call.__name__}. Detalhe: {str(e)}"

--- a/app/hooks/tool_hooks.py
+++ b/app/hooks/tool_hooks.py
@@ -1,6 +1,7 @@
 import json
 from typing import Callable, Dict, Any
 from agno.run import RunContext
+from datetime import datetime, timedelta
 
 def validate_selected_property_hook(run_context: RunContext, function_call: Callable, arguments: Dict[str, Any]) -> Any:
     """
@@ -16,31 +17,23 @@ def validate_selected_property_hook(run_context: RunContext, function_call: Call
         "Peça desculpas ao usuário. Peça que o usuário informe uma propriedade."
     )
 
-def validate_rate_limit_hook(run_context: RunContext, function_call: Callable, arguments: Dict[str, Any]) -> Any:
-    """
-    Hook Interceptor: Gerencia o cache e a execução das ferramentas de mídia.
-    Evita reprocessamento desnecessário, economiza requisições e filtra falsos positivos.
-    """
+def validate_rate_limit_hook(run_context: Any, function_call: Callable, arguments: Dict[str, Any]) -> Any:
+    """ Hook universal para evitar reprocessamento e controlar expiração (7 dias). """
+    session_state = run_context.session_state or {}
 
-    if run_context.session_state is None:
-        run_context.session_state = {}
+    delivered_media = session_state.get("delivered_media", {})
     
-    midias_entregues = run_context.session_state.get("midias_entregues", {})
+    search_key = json.dumps({"func": function_call.__name__, "args": arguments}, sort_keys=True)
 
-    clean_args = {k: v for k, v in arguments.items() if k not in ['run_context', 'session', 'session_state']}
-    key_data = {
-        "function_name": function_call.__name__,
-        "arguments": clean_args
-    }
+    if search_key in delivered_media:
+        saved_date_str = delivered_media[search_key]
+        try:
+            saved_date = datetime.fromisoformat(saved_date_str)
 
-    search_key = json.dumps(key_data, sort_keys=True)
-
-    if search_key in midias_entregues:
-        tool_name = function_call.__name__
-        return (
-            f"Aviso: A mídia solicitada ({tool_name}) já foi gerada com esses exatos parâmetros e entregue nesta sessão. "
-            f"Avise ao usuário que a imagem já está no histórico da conversa."
-        )
+            if datetime.now() - saved_date < timedelta(days=7):
+                return "A mídia solicitada já foi gerada com esses exatos parâmetros e entregue nesta sessão."
+        except Exception:
+            pass
 
 
     try:
@@ -51,8 +44,8 @@ def validate_rate_limit_hook(run_context: RunContext, function_call: Callable, a
         if not hasattr(result, 'images') or not result.images:
              return "Erro: A integração com o satélite retornou uma mídia vazia. Tente novamente."
 
-        midias_entregues[search_key] = True
-        run_context.session_state["midias_entregues"] = midias_entregues
+        delivered_media[search_key] = datetime.now().isoformat()
+        run_context.session_state["delivered_media"] = delivered_media
 
         return result
 

--- a/app/tools/property_analyst_tools.py
+++ b/app/tools/property_analyst_tools.py
@@ -1,5 +1,4 @@
 from io import BytesIO
-
 from agno.tools import tool
 from agno.tools.function import ToolResult
 from agno.run import RunContext
@@ -7,23 +6,14 @@ from agno.media import Image
 
 from app.hooks.tool_hooks import validate_selected_property_hook, validate_rate_limit_hook
 from app.utils.scripts.gee_scripts import retrieve_feature_images, retrieve_feature_biomass_image, query_pasture_statistics
-from app.utils.interfaces.property_stats import PastureStats, PropertyStats 
+from app.utils.interfaces.property_stats import PastureStats
 from app.utils.interfaces.property_record import RuralProperty
 
 
 @tool(tool_hooks=[validate_selected_property_hook, validate_rate_limit_hook])
 def generate_property_image(run_context: RunContext, car_codes: list[str]) -> ToolResult:
     """
-    Gera uma imagem de satélite em alta resolução (RGB) da propriedade rural,
-    incluindo a delimitação geográfica, com base nos últimos dois meses.
-
-    Use apenas quando o usuário pedir para visualizar a propriedade.
-
-    params:
-        car_codes (list[str]): Lista de códigos CAR da propriedade.
-
-    Return:
-        ToolResult: Imagem PNG da visão aérea com delimitação geográfica.
+    Gera uma imagem de satélite em alta resolução (RGB) da propriedade rural.
     """
     try:
         registered_properties = run_context.session_state['registered_properties']
@@ -36,10 +26,9 @@ def generate_property_image(run_context: RunContext, car_codes: list[str]) -> To
         img.save(buffer, format="PNG")
                 
         return ToolResult(
-            content=f"O contorno vermelho indica a delimitação geográfica da propriedade rural.",
+            content="O contorno vermelho indica a delimitação geográfica da propriedade rural.",
             images=[Image(content=buffer.getvalue())]
         )
-
     except Exception as e:
         return ToolResult(content=f"Erro ao gerar imagem: {str(e)}")
 
@@ -48,17 +37,10 @@ def generate_property_image(run_context: RunContext, car_codes: list[str]) -> To
 def generate_biomass_image(run_context: RunContext, car_codes: list[str], year: int = 2024) -> ToolResult:
     """
     Gera um mapa temático da biomassa (matéria seca) sobre os limites da propriedade rural.
-
-    params:
-        car_codes (list[str]): Lista de códigos CAR da propriedade.
-        year (int): O ano para a consulta dos dados (2000-2024).
-
-    Return:
-        ToolResult: Mapa renderizado em formato PNG.
     """
     try:
         registered_properties = run_context.session_state['registered_properties']
-        selected_property = next((prop for prop in registered_properties if prop["car_codes"] == ', '.join(car_codes)), None)
+        selected_property = next((prop for prop in registered_properties if prop["car_code"] == ', '.join(car_codes)), None)
         selected_property = RuralProperty.model_validate(selected_property)
 
         img = retrieve_feature_biomass_image(coords=selected_property.get_coords(), year=year)
@@ -67,56 +49,26 @@ def generate_biomass_image(run_context: RunContext, car_codes: list[str], year: 
         img.save(buffer, format="PNG")
                 
         return ToolResult(
-            content=f"Legenda: Azul claro (Alta concentração) a Roxo escuro (Baixa concentração).",
+            content="Legenda: Azul claro (Alta concentração) a Roxo escuro (Baixa concentração).",
             images=[Image(content=buffer.getvalue())]
         )
-
     except Exception as e:
-        return ToolResult(content=str(e))
+        return ToolResult(content=f"Erro ao gerar mapa de biomassa: {str(e)}")
 
 
 @tool(tool_hooks=[validate_selected_property_hook])
 def get_pasture_stats(run_context: RunContext, car_codes: list[str], year: int = 2024):
     """
-    Realiza uma análise técnica detalhada do uso do solo, com foco em pastagem, vigor vegetativo e biomassa
-    para a propriedade selecionada no contexto (CAR).
-    
-    Use esta ferramenta quando o usuário perguntar sobre:
-    - Saúde ou qualidade da pastagem (degradação, vigor).
-    - Quantidade de biomassa disponível.
-    - Classificação de uso do solo (LULC) incluindo: Silvicultura, Cana, Soja, Arroz, Café, Citrus, etc.
-    - Idade da pastagem.
-
-    params:
-        car_codes (list[str]): Lista de códigos CAR da propriedade.
-        year (str): O ano para a consulta dos dados (2000-2024).
-
-    Return:
-        Dicionário contendo a área de pastagem, vigor da pastagem, áreas de pastagem degradadas (baixo vigor), biomassa total e a idade.
+    Realiza uma análise técnica detalhada do uso do solo e pastagem.
     """
     try:
-        #properties_stats = run_context.session_state.get("properties_stats", [])
-        #property_stats = next((prop for prop in properties_stats if prop["id"] == property_id), None)
-        #new_property_stats = PropertyStats.model_validate(properties_stats) if property_stats else PropertyStats(id=property_id)
-        #
-        #for pasture_stats in new_property_stats.list_pasture_stats:
-        #    if pasture_stats.year == year:
-        #        return ToolResult(content=str(pasture_stats))
-            
+
         registered_properties = run_context.session_state["registered_properties"]
         selected_property = next((prop for prop in registered_properties if prop["car_code"] == ', '.join(car_codes)))
         selected_property = RuralProperty.model_validate(selected_property)
 
         new_pasture_stats: PastureStats = query_pasture_statistics(coords=selected_property.get_coords(), year=year)
 
-        #new_property_stats.list_pasture_stats.append(new_pasture_stats)
-
-        #if property_stats is not None:
-        #    properties_stats.remove(property_stats)
-        #properties_stats.append(new_property_stats.model_dump())
-        #run_context.session_state["properties_stats"] = properties_stats
-
         return ToolResult(content=str(new_pasture_stats))
     except Exception as e:
-        print(f"ERROR: {e}", flush=True)
-        return ToolResult(content=str(e))
+        return ToolResult(content=f"Erro na análise de pastagem: {str(e)}")

--- a/app/tools/property_analyst_tools.py
+++ b/app/tools/property_analyst_tools.py
@@ -10,10 +10,19 @@ from app.utils.interfaces.property_stats import PastureStats
 from app.utils.interfaces.property_record import RuralProperty
 
 
-@tool(tool_hooks=[validate_selected_property_hook])
+@tool(tool_hooks=[validate_selected_property_hook, validate_rate_limit_hook])
 def generate_property_image(run_context: RunContext, car_codes: list[str]) -> ToolResult:
     """
-    Gera uma imagem de satélite em alta resolução (RGB) da propriedade rural.
+    Gera uma imagem de satélite em alta resolução (RGB) da propriedade rural,
+    incluindo a delimitação geográfica, com base nos últimos dois meses.
+
+    Use apenas quando o usuário pedir para visualizar a propriedade.
+
+    params:
+        car_codes (list[str]): Lista de códigos CAR da propriedade.
+
+    Return:
+        ToolResult: Imagem PNG da visão aérea com delimitação geográfica.
     """
     try:
         registered_properties = run_context.session_state['registered_properties']
@@ -33,10 +42,17 @@ def generate_property_image(run_context: RunContext, car_codes: list[str]) -> To
         return ToolResult(content=f"Erro ao gerar imagem: {str(e)}")
 
 
-@tool(tool_hooks=[validate_selected_property_hook])
+@tool(tool_hooks=[validate_selected_property_hook, validate_rate_limit_hook])
 def generate_biomass_image(run_context: RunContext, car_codes: list[str], year: int = 2024) -> ToolResult:
     """
     Gera um mapa temático da biomassa (matéria seca) sobre os limites da propriedade rural.
+
+    params:
+        car_codes (list[str]): Lista de códigos CAR da propriedade.
+        year (int): O ano para a consulta dos dados (2000-2024). O ano mais recente é 2024.
+
+    Return:
+        ToolResult: Mapa renderizado em formato PNG.
     """
     try:
         registered_properties = run_context.session_state['registered_properties']
@@ -60,7 +76,20 @@ def generate_biomass_image(run_context: RunContext, car_codes: list[str], year: 
 @tool(tool_hooks=[validate_selected_property_hook])
 def get_pasture_stats(run_context: RunContext, car_codes: list[str], year: int = 2024):
     """
-    Realiza uma análise técnica detalhada do uso do solo e pastagem.
+    Recupera estatísticas de bimoassa, vigor vegetativo, idade da pastagem e classificação de uso do solo.
+   
+    Use esta ferramenta quando o usuário perguntar sobre:
+    - Saúde ou qualidade da pastagem (degradação, vigor).
+    - Quantidade de biomassa disponível.
+    - Classificação de uso do solo (LULC) incluindo: Silvicultura, Cana, Soja, Arroz, Café, Citrus, etc.
+    - Idade da pastagem.
+
+    params:
+        car_codes (list[str]): Lista de códigos CAR da propriedade.
+        year (str): O ano para a consulta dos dados (2000-2024). O ano mais recente é 2024.
+
+    Return:
+        Dicionário contendo a área de biomassa, vigor da pastagem, idade e uso e cobertura do solo.
     """
     try:
 


### PR DESCRIPTION
Descrição:
Refatoração das ferramentas de mídia pesada (Earth Engine) para aplicar o Princípio da Responsabilidade Única (SRP) e evitar reprocessamento por amnésia do LLM.

Interceptação no Hook: O validate_rate_limit_hook agora engloba a execução da ferramenta no bloco try-except.

Chave de Busca Permanente: Implementada geração de hash (JSON) baseado no nome da função e argumentos (sem data), garantindo a identificação de mídias idênticas pedidas na mesma sessão.

Gestão de Estado Centralizada: O controle do session_state (midias_entregues) foi totalmente movido para o hook.

Filtro de Falsos Positivos: O sistema agora aborta o salvamento no estado se a API retornar erro ou mídia vazia, permitindo novas tentativas da IA.

Limpeza das Tools: Ferramentas como generate_property_image tornaram-se funções "burras", focadas apenas na extração e retorno dos dados.