### PR TITLE
Feat/123 filtro escopo

### DIFF
--- a/app/guardrails/context_gate.py
+++ b/app/guardrails/context_gate.py
@@ -1,0 +1,81 @@
+"""Validação de escopo (Context) (#123)
+
+Decide se o conteúdo tem relação com o Pasto Legal. Se estiver fora, barra com
+um aviso que DIZ o assunto detectado.
+"""
+
+from pydantic import BaseModel, Field
+
+from agno.agent import Agent
+
+from app.configs.config import config
+
+
+class ResultadoContexto(BaseModel):
+    dentro_do_escopo: bool = Field(
+        ...,
+        description="True se tem relação com pastagem, solo, gado, fazenda, manejo "
+                    "ou agro, OU se é conversa normal (saudação). False só quando é "
+                    "claramente outro assunto.",
+    )
+    assunto: str = Field(
+        default="",
+        description="Quando FORA do escopo, o assunto detectado em 1-3 palavras "
+                    "(ex.: 'carro', 'futebol', 'prédio'). Vazio se dentro do escopo.",
+    )
+
+
+class ContextValidator:
+    """Julga UMA vez se o conteúdo está no escopo do Pasto Legal."""
+
+    _INSTRUCOES = (
+        "Você decide se a mensagem deve ser atendida pelo Pasto Legal, um "
+        "assistente sobre pastagem, solo, gado, fazenda, manejo e agropecuária.\n"
+        "DENTRO do escopo: perguntas sobre esses temas E também saudações, "
+        "agradecimentos e conversa normal.\n"
+        "FORA do escopo (dentro_do_escopo=false) APENAS quando é claramente sem "
+        "relação: esportes, política, celebridades, receitas, veículos, etc.\n"
+        "Quando estiver FORA, preencha 'assunto' com o tema detectado em 1-3 palavras."
+    )
+
+    def __init__(self, *textos: str):
+        conteudo = "\n".join(t for t in textos if t)
+        self._resultado = self._validar(conteudo)
+
+    def _validar(self, conteudo: str) -> ResultadoContexto:
+        if not conteudo.strip():
+            return ResultadoContexto(dentro_do_escopo=True)
+        try:
+            juiz = Agent(
+                model=config.model,
+                output_schema=ResultadoContexto,
+                instructions=self._INSTRUCOES,
+                markdown=False,
+            )
+            resposta = juiz.run(conteudo)
+            return resposta.content
+        except Exception:
+            return ResultadoContexto(dentro_do_escopo=True)  # fail-open
+
+    @property
+    def dentro_do_escopo(self) -> bool:
+        return self._resultado.dentro_do_escopo
+
+    @property
+    def assunto(self) -> str:
+        return self._resultado.assunto
+
+
+def mensagem_fora_escopo(assunto: str = "") -> str:
+    """Aviso amigável, citando o assunto detectado quando houver."""
+    if assunto:
+        return (
+            f"🌾 Detectei que sua mensagem é sobre **{assunto}**, que não faz parte "
+            "do meu escopo. Consigo te ajudar com pastagem, solo, gado e manejo da "
+            "sua propriedade. Pode reformular nesse contexto?"
+        )
+    return (
+        "🌾 Consigo te ajudar com temas da sua propriedade — pastagem, solo, gado e "
+        "manejo. Não identifiquei relação com esses assuntos na sua mensagem. "
+        "Pode reformular nesse contexto?"
+    )

--- a/app/steps/scope_step.py
+++ b/app/steps/scope_step.py
@@ -15,7 +15,6 @@ from app.services.audio.tts import generate_speech
 def _scope_executor(step_input: StepInput) -> StepOutput:
     """Barra conteúdo fora do escopo do Pasto Legal."""
     text = step_input.previous_step_content or step_input.get_input_as_string() or ""
-    print("DEBUG scope text:", repr(text), flush=True)
 
     contexto = ContextValidator(text)
     if contexto.dentro_do_escopo:

--- a/app/steps/scope_step.py
+++ b/app/steps/scope_step.py
@@ -1,0 +1,41 @@
+"""Scope guardrail step: barra conteúdo fora do escopo do Pasto Legal (#123).
+
+Reusa o texto consolidado montado pelo input_step. Se o conteúdo estiver
+claramente fora do tema (pastagem/agro), bloqueia com uma mensagem amigável
+(em áudio se o usuário mandou áudio). Caso contrário, passa o texto adiante.
+"""
+from agno.utils.log import log_error
+from agno.workflow import Step
+from agno.workflow.types import StepInput, StepOutput
+
+from app.guardrails.context_gate import ContextValidator, mensagem_fora_escopo
+from app.services.audio.tts import generate_speech
+
+
+def _scope_executor(step_input: StepInput) -> StepOutput:
+    """Barra conteúdo fora do escopo do Pasto Legal."""
+    text = step_input.previous_step_content or step_input.get_input_as_string() or ""
+    print("DEBUG scope text:", repr(text), flush=True)
+
+    contexto = ContextValidator(text)
+    if contexto.dentro_do_escopo:
+        return StepOutput(content=text)
+
+    aviso = mensagem_fora_escopo(contexto.assunto)
+
+    if step_input.audio:
+        try:
+            user_id = step_input.workflow_session.user_id if step_input.workflow_session else "default"
+            audio = generate_speech(aviso, user_id=user_id)
+            if audio:
+                return StepOutput(content=aviso, audio=[audio], stop=True, success=False)
+        except Exception as e:
+            log_error(f"scope TTS failed: {e}")
+
+    return StepOutput(content=aviso, stop=True, success=False)
+
+
+scope_step = Step(
+    name="Scope Guardrail",
+    executor=_scope_executor,
+)

--- a/app/workflows/pasto_legal_workflow.py
+++ b/app/workflows/pasto_legal_workflow.py
@@ -37,6 +37,7 @@ from app.steps.guardrails_step import guardrails_step
 from app.steps.input_step import input_step
 from app.steps.summarization_step import summarization_step
 from app.workflows.feedback_workflow import feedback_workflow
+from app.steps.scope_step import scope_step
 
 
 def _route_selector(step_input: StepInput, session_state: Dict[str, Any]) -> str:
@@ -128,6 +129,7 @@ pasto_legal_workflow = PersistOnSuccessWorkflow(
     steps=[
         input_step,
         guardrails_step,
+        scope_step, 
         Condition(
             name="Onboarding Check",
             evaluator=_needs_onboarding,

--- a/app/workflows/pasto_legal_workflow.py
+++ b/app/workflows/pasto_legal_workflow.py
@@ -128,8 +128,8 @@ pasto_legal_workflow = PersistOnSuccessWorkflow(
     num_history_runs=1,
     steps=[
         input_step,
+        scope_step,
         guardrails_step,
-        scope_step, 
         Condition(
             name="Onboarding Check",
             evaluator=_needs_onboarding,


### PR DESCRIPTION
## Filtro de Escopo de Imagens/Mensagens (#123)

### O que faz
Adiciona o **filtro de escopo** da #123: barra conteúdo (imagem, áudio ou texto) que está **fora do domínio do Pasto Legal** (pastagem, solo, gado, agro). Ex.: foto de carro/prédio ou pergunta sobre futebol → bloqueado com um aviso amigável (falado, se a entrada foi áudio).

### Como funciona
- **`app/steps/scope_step.py`** (novo): lê o texto consolidado do `input_step`, valida o escopo via `ContextValidator` e **bloqueia o fluxo** (`stop=True`) quando está fora — citando o assunto detectado.
- **`app/guardrails/context_gate.py`** (novo): a lógica do `ContextValidator` + a mensagem de fora de escopo.
- Encaixado **antes do `guardrails_step`** no `pasto_legal_workflow`, pra ler a descrição/transcrição que o `input_step` monta.

### Critério de aceite da #123
- [x] Filtro de escopo (guardrail) bloqueando conteúdo fora do contexto do projeto.

### Observação
A descrição de imagem e a transcrição de áudio já foram implementadas na reestruturação (`input_step`). Este PR completa o pedaço que faltava da #123: o **filtro de escopo**.