### PR TITLE
fix: exibicao resiliente de midia no streamlit (#137)

### DIFF
--- a/app/interfaces/streamlit/streamlit_webapp.py
+++ b/app/interfaces/streamlit/streamlit_webapp.py
@@ -159,10 +159,12 @@ for message in st.session_state.messages:
         st.markdown(message["content"])
         if "images" in message:
             for img in message["images"]:
-                st.image(img, use_container_width=True)
+                if img is not None:
+                    st.image(img, use_container_width=True)
         if "audio" in message:
             for aud in message["audio"]:
-                st.audio(aud, format="audio/ogg")
+                if aud is not None:
+                    st.audio(aud, format="audio/ogg")
 
 # Inputs do usuário
 if 'file_uploader_key' not in st.session_state:
@@ -232,6 +234,7 @@ if user_query:
         
         full_response = ""
         response = None
+        audio_to_display = []
         
         try:
             run_kwargs = {
@@ -285,8 +288,8 @@ if user_query:
 
             if response and response.images:
                 for img in response.images:
-                    st.image(img.content, use_container_width=True)
-
+                    if img.content is not None:
+                        st.image(img.content, use_container_width=True)
             audio_to_display = []
             if response and hasattr(response, 'audio') and response.audio:
                 audio_to_display.extend(response.audio)


### PR DESCRIPTION
Corrige o crash na exibição de mídia no Streamlit:
- `audio_to_display` inicializado antes do `try` (evita o NameError que mascarava o erro real).
- Guards de `None` em `st.image`/`st.audio` (evita `'NoneType' object has no attribute 'format'`).

Fixes #137